### PR TITLE
Update kcpassword to use python3, error on failure in enable_autologin

### DIFF
--- a/enable_autologin
+++ b/enable_autologin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 function usage() {
 	echo "$0 <username> <password>"

--- a/kcpassword
+++ b/kcpassword
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Port of Gavin Brock's Perl kcpassword generator to Python, by Tom Taylor
 # <tom@tomtaylor.co.uk>.


### PR DESCRIPTION
This should fix #2. It looks like macOS 12.3 removed Python 2.7 from the system, so the shebang in `kcpassword` would error because it can't find python in the PATH. I've also added `-e` to enable_autologin since that script would silently succeed without it, especially when it is run as part of a script 