### PR TITLE
Python3 fixes

### DIFF
--- a/kcpassword
+++ b/kcpassword
@@ -8,10 +8,11 @@
 import sys
 import os
 
+
 def kcpassword(passwd):
     # The magic 11 bytes - these are just repeated
     # 0x7D 0x89 0x52 0x23 0xD2 0xBC 0xDD 0xEA 0xA3 0xB9 0x1F
-    key = [125,137,82,35,210,188,221,234,163,185,31]
+    key = [125, 137, 82, 35, 210, 188, 221, 234, 163, 185, 31]
     key_len = len(key)
 
     passwd = [ord(x) for x in list(passwd)]
@@ -22,12 +23,13 @@ def kcpassword(passwd):
 
     for n in range(0, len(passwd), len(key)):
         ki = 0
-        for j in range(n, min(n+len(key), len(passwd))):
+        for j in range(n, min(n + len(key), len(passwd))):
             passwd[j] = passwd[j] ^ key[ki]
             ki += 1
 
     passwd = [chr(x) for x in passwd]
     return "".join(passwd)
+
 
 if __name__ == "__main__":
     passwd = kcpassword(sys.argv[1])

--- a/kcpassword
+++ b/kcpassword
@@ -15,25 +15,22 @@ def kcpassword(passwd):
     key = [125, 137, 82, 35, 210, 188, 221, 234, 163, 185, 31]
     key_len = len(key)
 
-    passwd = [ord(x) for x in list(passwd)]
+    passwd = list(bytearray(passwd, "utf8"))
     # pad passwd length out to an even multiple of key length
     r = len(passwd) % key_len
     if (r > 0):
         passwd = passwd + [0] * (key_len - r)
 
     for n in range(0, len(passwd), len(key)):
-        ki = 0
         for j in range(n, min(n + len(key), len(passwd))):
-            passwd[j] = passwd[j] ^ key[ki]
-            ki += 1
+            passwd[j] = passwd[j] ^ key[j % key_len]
 
-    passwd = [chr(x) for x in passwd]
-    return "".join(passwd)
+    return bytearray(passwd)
 
 
 if __name__ == "__main__":
     passwd = kcpassword(sys.argv[1])
     fd = os.open('/etc/kcpassword', os.O_WRONLY | os.O_CREAT, 0o600)
-    file = os.fdopen(fd, 'w')
+    file = os.fdopen(fd, 'wb')
     file.write(passwd)
     file.close()


### PR DESCRIPTION
Hi,

even though autologin works OK, there's problem with unlocking keychain when connected through SSH by doing `security unlock-keychain -p <password>`, which fails with incorrect password. Even when using graphical UI when some application requests keychain access and password dialog pops up, the correct password doesn't work here and dialog just shakes as if the password was incorrect.

Proposed changes fix this issue which was caused by python3 `chr()` and `ord()` functions working with unicode as opposed to ASCII in python 2.

I tried with shorter ASCII passwords and also with `Žluťoučký kůň`. All of the passwords worked OK.

While not being part of this PR, I noticed that last paragraph of `README.md` probably isn't valid anymore.

Thank you.